### PR TITLE
Add secrets management

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,18 @@ export const runtimeConfig: GcpConfig = {
   event: "create"
 };
 ```
+
+## Secrets Management
+
+In the root of your project you can define a `secrets.json` file which must be a key/value structure where the value is the name of the secret.
+
+The values represent the name of the secret within GCP Secret Manager. The keys within the JSON file do not matter (you could generate type definitions for usage as constants within your application code though).
+
+> Note: No secret values should be contained in here! You need to configure secret values manually within GCP (either via the console or CLI).
+
+```json
+{
+  bigCommerceAccessToken: "bigcommerce-access-token",
+  someOtherSecret: "name-of-my-secret-in-gcp"
+}
+```

--- a/cli/build.ts
+++ b/cli/build.ts
@@ -12,6 +12,7 @@ export const cmdBuild: cliCommand = (argv) => {
     "--debug": Boolean,
     "--project": String,
     "--region": String,
+    "--env": String,
 
     // Aliases
     "-h": "--help",
@@ -36,6 +37,7 @@ export const cmdBuild: cliCommand = (argv) => {
     Options
       --project=[name]  Set a project name
       --region=[region] Set a valid region (defaults to europe-west2 for GCP)
+      --env=[env]       Set an environment eg: production, staging, dev, uat
       --help, -h        Displays this message
       --debug, -d       Outputs debug logging
     For more information run a command with the --help flag
@@ -55,5 +57,12 @@ export const cmdBuild: cliCommand = (argv) => {
   }
 
   const region = args["--region"] ?? "europe-west2";
-  return build(dir, (args["--project"] as unknown) as string, region, !!args["--debug"]);
+  const environment = args["--env"] ?? "dev";
+  return build({
+    dir,
+    project: (args["--project"] as unknown) as string,
+    region,
+    debug: !!args["--debug"],
+    environment,
+  });
 };


### PR DESCRIPTION
The idea here is to generate secrets that will live in GCP's Secrets Manager. App devs can then access these values using the secret manager SDK. This is preferable and more secure than using environment variables.

This only provisions the secret manager secret. It contains an initial value and I don't think we should bother with managing these values ourselves right now. Should be up to devs to populate the secret manager secrets with real values manually (via CLI or the cosnole).