### PR TITLE
Handle conflicts with source code bucket names

### DIFF
--- a/build/index.ts
+++ b/build/index.ts
@@ -34,8 +34,7 @@ export default (buildOpts: Partial<BuildOpts>): { config: BaseConfig; app: App }
   const stack = new GcpStack(app, options.cloud.gcp.project, {
     outDir: buildOutDir,
     environment: buildOpts.environment ?? "dev",
-    project: options.cloud.gcp.project,
-    region: options.cloud.gcp.region,
+    gcpOptions: options.cloud.gcp,
     envVars: options.runtimeEnvironmentVariables,
     secretNames: options.secretVariableNames,
   });
@@ -84,6 +83,14 @@ function mergeConfig(rootOpts: DeepPartial<RootConfig>, cmdOpts: Partial<BuildOp
         project: envSpecificRoot?.cloud?.gcp?.project ?? defaultRoot?.cloud?.gcp?.project ?? "",
         region:
           envSpecificRoot?.cloud?.gcp?.region ?? defaultRoot?.cloud?.gcp?.region ?? "europe-west2",
+        sourceCodeStorage: {
+          bucketOptions: {
+            name:
+              envSpecificRoot?.cloud?.gcp?.sourceCodeStorage?.bucketOptions?.name ??
+              defaultRoot?.cloud?.gcp?.sourceCodeStorage?.bucketOptions?.name ??
+              "",
+          },
+        },
       },
     },
     tfConfig: {

--- a/build/index.ts
+++ b/build/index.ts
@@ -84,10 +84,10 @@ function mergeConfig(rootOpts: DeepPartial<RootConfig>, cmdOpts: Partial<BuildOp
         region:
           envSpecificRoot?.cloud?.gcp?.region ?? defaultRoot?.cloud?.gcp?.region ?? "europe-west2",
         sourceCodeStorage: {
-          bucketOptions: {
+          bucket: {
             name:
-              envSpecificRoot?.cloud?.gcp?.sourceCodeStorage?.bucketOptions?.name ??
-              defaultRoot?.cloud?.gcp?.sourceCodeStorage?.bucketOptions?.name ??
+              envSpecificRoot?.cloud?.gcp?.sourceCodeStorage?.bucket?.name ??
+              defaultRoot?.cloud?.gcp?.sourceCodeStorage?.bucket?.name ??
               "",
           },
         },

--- a/schemas/cloudseed.schema.json
+++ b/schemas/cloudseed.schema.json
@@ -29,7 +29,7 @@
                 },
                 "sourceCodeStorage": {
                   "properties": {
-                    "bucketOptions": {
+                    "bucket": {
                       "properties": {
                         "name": {
                           "type": "string"
@@ -543,7 +543,7 @@
                 },
                 "sourceCodeStorage": {
                   "properties": {
-                    "bucketOptions": {
+                    "bucket": {
                       "properties": {
                         "name": {
                           "type": "string"

--- a/schemas/cloudseed.schema.json
+++ b/schemas/cloudseed.schema.json
@@ -26,6 +26,19 @@
                 },
                 "region": {
                   "type": "string"
+                },
+                "sourceCodeStorage": {
+                  "properties": {
+                    "bucketOptions": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
                 }
               },
               "type": "object"
@@ -527,6 +540,19 @@
                 },
                 "region": {
                   "type": "string"
+                },
+                "sourceCodeStorage": {
+                  "properties": {
+                    "bucketOptions": {
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
                 }
               },
               "type": "object"

--- a/stacks/gcp/GcpStack.ts
+++ b/stacks/gcp/GcpStack.ts
@@ -51,7 +51,7 @@ export default class GcpStack extends TerraformStack {
       // Creates a storage bucket for the functions source to be uploaded to.
       const bucket = new StorageBucket(this, "FuncSourceBucket", {
         name:
-          options.gcpOptions.sourceCodeStorage?.bucketOptions?.name ??
+          options.gcpOptions.sourceCodeStorage?.bucket?.name ??
           `${options.gcpOptions.project}-functions`,
         location: this.options.gcpOptions.region.toUpperCase(),
       });

--- a/stacks/gcp/GcpStack.ts
+++ b/stacks/gcp/GcpStack.ts
@@ -39,8 +39,8 @@ export default class GcpStack extends TerraformStack {
 
     // Configure the Google Provider.
     new GoogleProvider(this, "Google", {
-      region: this.options.region,
-      project: this.options.project,
+      project: this.options.gcpOptions.project,
+      region: this.options.gcpOptions.region,
     });
 
     const functions = this.getFunctions();
@@ -50,8 +50,10 @@ export default class GcpStack extends TerraformStack {
       new ArchiveProvider(this, "Archive");
       // Creates a storage bucket for the functions source to be uploaded to.
       const bucket = new StorageBucket(this, "FuncSourceBucket", {
-        name: `${id}-functions`,
-        location: this.options.region.toUpperCase(),
+        name:
+          options.gcpOptions.sourceCodeStorage?.bucketOptions?.name ??
+          `${options.gcpOptions.project}-functions`,
+        location: this.options.gcpOptions.region.toUpperCase(),
       });
       functions.forEach(func => this.generateFunction(func, bucket));
     }
@@ -87,8 +89,8 @@ export default class GcpStack extends TerraformStack {
       entryPoint: "default",
       environmentVariables: {
         NODE_ENV: this.options.environment,
-        GCP_PROJECT: this.options.project,
-        GCP_REGION: this.options.region,
+        GCP_PROJECT: this.options.gcpOptions.project,
+        GCP_REGION: this.options.gcpOptions.region,
         ...envVars,
       },
 
@@ -116,7 +118,7 @@ export default class GcpStack extends TerraformStack {
         name: func.name,
         schedule: func.schedule,
         pubsubTarget: {
-          topicName: `projects/${this.options.project}/topics/${scheduledTopic.name}`,
+          topicName: `projects/${this.options.gcpOptions.project}/topics/${scheduledTopic.name}`,
           data: "c2NoZWR1bGU=",
         },
       });
@@ -195,7 +197,7 @@ export default class GcpStack extends TerraformStack {
     vpcAccessConnectorName: string,
     vpcAccessConnectorCidrRange: string,
   ) {
-    const region = this.options.region;
+    const region = this.options.gcpOptions.region;
     const netName = "static-ip-vpc";
     if (!this.existingStaticIpVpcSubnets.length) {
       const network = new ComputeNetwork(this, netName, {

--- a/stacks/gcp/types.ts
+++ b/stacks/gcp/types.ts
@@ -1,10 +1,10 @@
 import { GcpConfig } from "../../runtime";
+import { BaseConfig } from "../../utils/rootConfig";
 
 export type StackOptions = {
   outDir: string;
   environment: string;
-  project: string;
-  region: string;
+  gcpOptions: BaseConfig["cloud"]["gcp"];
   envVars?: Record<string, string>;
   secretNames?: string[];
 };

--- a/utils/rootConfig.ts
+++ b/utils/rootConfig.ts
@@ -18,6 +18,11 @@ export interface BaseConfig {
     gcp: {
       project: string;
       region: string;
+      sourceCodeStorage?: {
+        bucketOptions?: {
+          name: string;
+        };
+      };
     };
   };
   tfConfig: {

--- a/utils/rootConfig.ts
+++ b/utils/rootConfig.ts
@@ -19,7 +19,7 @@ export interface BaseConfig {
       project: string;
       region: string;
       sourceCodeStorage?: {
-        bucketOptions?: {
+        bucket?: {
           name: string;
         };
       };


### PR DESCRIPTION
We have seen cases where two or more cloud seed infrastructure deployments conflict with each other if they are targeting the same GCP project.

This PR gives the user the ability to manually resolve any potential conflicts around global bucket names.

This PR adds an extra config for source code storage, specifically an option to specify the source code backing bucket name.

Future PRs will address other potential conflicts as they show up.