### PR TITLE
Fix race condition where public permissions for function is created before actual function

### DIFF
--- a/stacks/gcp/GcpStack.ts
+++ b/stacks/gcp/GcpStack.ts
@@ -96,7 +96,7 @@ export default class GcpStack extends TerraformStack {
     });
 
     if (func.type === "http") {
-      this.configureHttpFunction(func);
+      this.configureHttpFunction(func, cloudFunc);
     }
 
     // Create pubsub topics if they don't exist already.
@@ -135,7 +135,7 @@ export default class GcpStack extends TerraformStack {
     }
   }
 
-  private configureHttpFunction(config: GcpFunction) {
+  private configureHttpFunction(config: GcpFunction, func: CloudfunctionsFunction) {
     if (config.type !== "http") {
       return;
     }
@@ -143,7 +143,7 @@ export default class GcpStack extends TerraformStack {
     // Configure if the http function is publically invokable.
     if (config.public) {
       new CloudfunctionsFunctionIamMember(this, config.name + "-http-invoker", {
-        cloudFunction: config.name,
+        cloudFunction: func.name,
         role: "roles/cloudfunctions.invoker",
         member: "allUsers",
       });


### PR DESCRIPTION
This PR fixes a race condition during Terraform deployment, where the creation of an IAM public invoker permission for a function is attempted before the actual function resource itself.

By getting the name token expression directly from the function Construct, Terraform will be forced to add a function dependency to this IAM member resource.

Just to be clear on what the difference is ... here are the `cdk.tf.json` generated outputs before and after this code change:

BEFORE:
```json
{
        "cloud_function": "func",
        "member": "allUsers",
        "role": "roles/cloudfunctions.invoker"
}
```
AFTER:
```json
{
        "cloud_function": "${google_cloudfunctions_function.testgcpproject_func_12345678.name}",
        "member": "allUsers",
        "role": "roles/cloudfunctions.invoker"
}
```
