### PR TITLE
Add support for Queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,6 @@ export default fn;
 export const runtimeConfig: GcpConfig = {
   cloud: "gcp",
   type: "queue",
-  // By defining the queueName it will create the queue for you.
-  queueName: "hello-world",
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,16 +75,18 @@ export const runtimeConfig: GcpConfig = {
 
 ```typescript
 import { CloudEventFunction } from "@google-cloud/functions-framework";
-import { GcpConfig } from "@space48/cloud-seed";
+import type { GcpConfig } from "@space48/cloud-seed";
 
 const fn: CloudEventFunction (data) => {
   console.log("This is a event triggered function", data);
 };
 
+export default fn;
+
 export const runtimeConfig: GcpConfig = {
   cloud: "gcp",
   type: "event",
-  // By defining the topicName it will create to the topic for you.
+  // By defining the topicName it will create the topic for you.
   topicName: "hello-world",
 };
 ```
@@ -93,7 +95,7 @@ export const runtimeConfig: GcpConfig = {
 
 ```typescript
 import { CloudEventFunction } from "@google-cloud/functions-framework";
-import { GcpConfig } from "@space48/cloud-seed";
+import type { GcpConfig } from "@space48/cloud-seed";
 
 const fn: CloudEventFunction = (data) => {
   console.log("This is a scheduled triggered function", data);
@@ -108,11 +110,32 @@ export const runtimeConfig: GcpConfig = {
 };
 ```
 
+### Queues:
+
+```typescript
+import { HttpFunction } from "@google-cloud/functions-framework";
+import type { GcpConfig } from "@space48/cloud-seed";
+
+const fn: HttpFunction = (req, res) => {
+  console.log(req.body);
+  return res.sendStatus(200);
+};
+
+export default fn;
+
+export const runtimeConfig: GcpConfig = {
+  cloud: "gcp",
+  type: "queue",
+  // By defining the queueName it will create the queue for you.
+  queueName: "hello-world",
+};
+```
+
 ### Firestore document triggers:
 
 ```typescript
 import { CloudEventFunction } from "@google-cloud/functions-framework";
-import { GcpConfig } from "@space48/cloud-seed";
+import type { GcpConfig } from "@space48/cloud-seed";
 
 const fn: CloudEventFunction = (data) => {
   console.log("This is a firestore triggered function", data);
@@ -133,7 +156,7 @@ export const runtimeConfig: GcpConfig = {
 
 ```typescript
 import { CloudEventFunction } from "@google-cloud/functions-framework";
-import { GcpConfig } from "@space48/cloud-seed";
+import type { GcpConfig } from "@space48/cloud-seed";
 
 const fn: CloudEventFunction = (data) => {
   console.log("This is a cloud storage triggered function", data);

--- a/build/esbuild/bundle.ts
+++ b/build/esbuild/bundle.ts
@@ -50,11 +50,10 @@ function generateFunctionName(file: string) {
     .replace(/(src|index|functions|function|\.ts)/g, "")
     .replace(/^\//, "")
     .replace(/\/$/, "")
-    .replace(/[\/]{2,}/g, "/")
-    .replace(/\//g, "-")
-    .replace(/[-_]{2,}/g, "-")
-    .replace(/^[-_]+/, "")
-    .replace(/[-_]+$/, "");
+    .replace(/[\/_]/g, "-")
+    .replace(/[-]{2,}/g, "-")
+    .replace(/^[-]+/, "")
+    .replace(/[-]+$/, "");
 }
 
 function detectRuntimeConfig(node: ts.Node) {

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,7 @@ More information, see:
 - [Creating HTTP Functions](./http.md)
 - [Creating PubSub Topics and Subscriptions](./pubsub.md)
 - [Creating Scheduled Functions](./scheduled.md)
+- [Creating Queue Functions](./queue.md)
 - [Creating Firestore triggered Functions](./firestore.md)
 - [Creating Cloud Storage triggered Functions](./storage.md)
 - [Creating Secrets](./secrets.md)

--- a/docs/pubsub.md
+++ b/docs/pubsub.md
@@ -5,18 +5,19 @@ If you want your function to be subscribed to a pubsub topic, you can use the `e
 ## Code sample
 
 ```typescript
-import { EventFunction } from "@google-cloud/functions-framework/build/src/functions";
-import { GcpConfig } from "@space48/cloud-seed";
+import { CloudEventFunction } from "@google-cloud/functions-framework";
+import type { GcpConfig } from "@space48/cloud-seed";
 
-const fn: EventFunction (data) => {
+const fn: CloudEventFunction (data) => {
   console.log("This is a event triggered function", data);
 };
+
+export default fn;
 
 export const runtimeConfig: GcpConfig = {
   cloud: "gcp",
   type: "event",
-  // By defining the topicName it will create to the topic for you.
+  // By defining the topicName it will create the topic for you.
   topicName: "hello-world",
 };
 ```
-

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -1,0 +1,24 @@
+# Queue Functions
+
+If you want your function to be triggered by a Cloud Tasks queue, you can use the `queue` type in the runtimeConfig, which requires the `queueName` property which is a string defining the name of the queue you'd like to create.
+
+## Code sample
+
+```typescript
+import { HttpFunction } from "@google-cloud/functions-framework";
+import type { GcpConfig } from "@space48/cloud-seed";
+
+const fn: HttpFunction = (req, res) => {
+  console.log(req.body);
+  return res.sendStatus(200);
+};
+
+export default fn;
+
+export const runtimeConfig: GcpConfig = {
+  cloud: "gcp",
+  type: "queue",
+  // By defining the queueName it will create the queue for you.
+  queueName: "hello-world",
+};
+```

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -1,6 +1,6 @@
 # Queue Functions
 
-If you want your function to be triggered by a Cloud Tasks queue, you can use the `queue` type in the runtimeConfig, which requires the `queueName` property which is a string defining the name of the queue you'd like to create.
+If you want your function to be triggered by a Cloud Tasks queue, you can use the `queue` type in the runtimeConfig.
 
 ## Code sample
 
@@ -18,7 +18,5 @@ export default fn;
 export const runtimeConfig: GcpConfig = {
   cloud: "gcp",
   type: "queue",
-  // By defining the queueName it will create the queue for you.
-  queueName: "hello-world",
 };
 ```

--- a/stacks/gcp/GcpStack.ts
+++ b/stacks/gcp/GcpStack.ts
@@ -7,6 +7,7 @@ import {
   CloudfunctionsFunctionConfig,
   CloudfunctionsFunctionIamMember,
   CloudSchedulerJob,
+  CloudTasksQueue,
   ComputeAddress,
   ComputeNetwork,
   ComputeRouter,
@@ -25,6 +26,7 @@ import { StackOptions, GcpFunction } from "./types";
 export default class GcpStack extends TerraformStack {
   private options: StackOptions;
   private existingTopics: string[] = [];
+  private existingQueues: string[] = [];
   private existingStaticIpVpcSubnets: string[] = [];
   constructor(scope: Construct, id: string, options: StackOptions) {
     super(scope, id);
@@ -103,6 +105,7 @@ export default class GcpStack extends TerraformStack {
     if (func.type === "event" && !this.existingTopics.includes(func.topicName)) {
       new PubsubTopic(this, func.topicName, {
         name: func.topicName,
+        messageRetentionDuration: func.topicConfig?.messageRetentionDuration,
       });
       this.existingTopics.push(func.topicName);
     }
@@ -120,6 +123,26 @@ export default class GcpStack extends TerraformStack {
           data: "c2NoZWR1bGU=",
         },
       });
+    }
+
+    // Create Cloud Tasks queue if it doesn't exist already
+    if (func.type === "queue" && !this.existingQueues.includes(func.queueName)) {
+      new CloudTasksQueue(this, func.queueName, {
+        name: func.queueName,
+        location: this.options.gcpOptions.region,
+        rateLimits: {
+          maxConcurrentDispatches: func.queueConfig?.maxConcurrentDispatches,
+          maxDispatchesPerSecond: func.queueConfig?.maxDispatchesPerSecond,
+        },
+        retryConfig: {
+          maxAttempts: func.queueConfig?.maxAttempts,
+          minBackoff: func.queueConfig?.minBackoff,
+          maxBackoff: func.queueConfig?.maxBackoff,
+          maxDoublings: func.queueConfig?.maxDoublings,
+          maxRetryDuration: func.queueConfig?.maxRetryDuration,
+        },
+      });
+      this.existingQueues.push(func.queueName);
     }
 
     // Configure static IP constraint
@@ -153,7 +176,7 @@ export default class GcpStack extends TerraformStack {
   private generateFunctionTriggerConfig(
     config: GcpFunction,
   ): Pick<CloudfunctionsFunctionConfig, "triggerHttp" | "eventTrigger"> {
-    if (config.type === "http") {
+    if (config.type === "http" || config.type === "queue") {
       return {
         triggerHttp: true,
       };

--- a/stacks/gcp/GcpStack.ts
+++ b/stacks/gcp/GcpStack.ts
@@ -126,9 +126,9 @@ export default class GcpStack extends TerraformStack {
     }
 
     // Create Cloud Tasks queue if it doesn't exist already
-    if (func.type === "queue" && !this.existingQueues.includes(func.queueName)) {
-      new CloudTasksQueue(this, func.queueName, {
-        name: func.queueName,
+    if (func.type === "queue" && !this.existingQueues.includes(func.name)) {
+      new CloudTasksQueue(this, func.name + "-queue", {
+        name: func.name,
         location: this.options.gcpOptions.region,
         rateLimits: {
           maxConcurrentDispatches: func.queueConfig?.maxConcurrentDispatches,
@@ -142,7 +142,7 @@ export default class GcpStack extends TerraformStack {
           maxRetryDuration: func.queueConfig?.maxRetryDuration,
         },
       });
-      this.existingQueues.push(func.queueName);
+      this.existingQueues.push(func.name);
     }
 
     // Configure static IP constraint

--- a/types/runtime.ts
+++ b/types/runtime.ts
@@ -24,11 +24,28 @@ export type HttpConfig = {
 export type EventConfig = {
   type: "event";
   topicName: string;
+  topicConfig?: {
+    messageRetentionDuration?: string;
+  };
 } & FunctionConfig;
 
 export type ScheduleConfig = {
   type: "schedule";
   schedule: string;
+} & FunctionConfig;
+
+export type QueueConfig = {
+  type: "queue";
+  queueName: string;
+  queueConfig?: {
+    maxDispatchesPerSecond?: number;
+    maxConcurrentDispatches?: number;
+    maxAttempts?: number;
+    maxRetryDuration?: string;
+    minBackoff?: string;
+    maxBackoff?: string;
+    maxDoublings?: number;
+  };
 } & FunctionConfig;
 
 export type FirestoreConfig = {
@@ -50,6 +67,7 @@ export type GcpConfig = (
   | HttpConfig
   | EventConfig
   | ScheduleConfig
+  | QueueConfig
   | FirestoreConfig
   | StorageConfig
 ) & {

--- a/types/runtime.ts
+++ b/types/runtime.ts
@@ -36,7 +36,6 @@ export type ScheduleConfig = {
 
 export type QueueConfig = {
   type: "queue";
-  queueName: string;
   queueConfig?: {
     maxDispatchesPerSecond?: number;
     maxConcurrentDispatches?: number;


### PR DESCRIPTION
This PR adds long-awaited support for queues.

A new config option is provided (`QueueConfig`) where the user can set options for creating/updating queues.