### PR TITLE
Dev mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/Space48/cloud-seed/compare/v4.0.0...HEAD)
 
+### Added
+
+- Cloud Seed commands can now discover the cloudseed.json configuration file for the project when run from within a subdirectory.
+
 ## [v4.0.0](https://github.com/Space48/cloud-seed/compare/v3.0.0...v4.0.0)
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `cloud-seed run` command to run functions locally with automatic rebuilding on changes. See `README.md` for documentation on how to use this command.
 - Cloud Seed commands can now discover the cloudseed.json configuration file for the project when run from within a subdirectory.
 
 ## [v4.0.0](https://github.com/Space48/cloud-seed/compare/v3.0.0...v4.0.0)

--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ terraform chdir=[buildDir] plan -out=plan
 terraform chdir=[buildDir] apply plan
 ```
 
+## Running functions locally for testing
+
+You can start the local development server for a function by running:
+
+```
+npx @space48/cloud-seed run src/myFirstFunction.ts --env environment
+```
+
+The development server will build the function and expose it on http://localhost:3000/ so you can trigger it with a HTTP request. Any changes you make to the source code of the function will rebuild it and restart the server, allowing you to keep testing without having to manually run any additional commands.
+
+Tips and tricks:
+
+- The development server does not require access to a cloud project to run the function locally. However, if your function code accesses any cloud resources, such as message queues or databases, you will need to authenticate with the cloud to allow it. For example, you can authenticate with GCP by running the `gcloud auth login` command in gcloud CLI.
+- The development server runs a single cloud function in isolation. If you want to test multiple functions, you can run multiple development servers on different ports using the `--port` option. Keep in mind that this won't automatically connect the functions and allow then to interract with each other. Your function code will have to be aware that it is running in development and adjust the endpoints it uses accordingly. You can use the `CLOUD_SEED_ENVIRONMENT` environment variable to write conditional code for running in the development environment.
+- Any cloud function can be triggered by a HTTP request, regardless of its type. However, some function types may require the request data to follow a specific format or use a specific encoding. Refer to the official documentation for the cloud service you're using for details on how to format your function input.
+- The development server automatically loads the environment variables you have defined in `cloudseed.json` for the provided environment and exposes them to the function. You can use this to configure a dedicated development environment, with appropriate configuration, to be shared by anyone running the project locally. Additionally, any environment variables with the same names defined in your environment will override the values from the configuration file. This is useful to temporarily modify the configuration for testing without having to modify the `cloudseed.json` file.
+
 # How does this work?
 
 Each Cloud Function you wish to define can live anywhere within the `src` directory, how you structure this is up to you.

--- a/bin/entrypoint.ts
+++ b/bin/entrypoint.ts
@@ -5,6 +5,7 @@ export type cliCommand = (argv?: string[]) => void;
 const commands: { [command: string]: () => Promise<cliCommand> } = {
   build: async () => await import("../cli/build.js").then(i => i.cmdBuild),
   list: async () => await import("../cli/list.js").then(i => i.cmdList),
+  run: async () => await import("../cli/run.js").then(i => i.cmdRun),
 };
 
 const args = arg(

--- a/build/esbuild/bundle.ts
+++ b/build/esbuild/bundle.ts
@@ -2,6 +2,7 @@ import { BuildOptions, buildSync } from "esbuild";
 import { writeFileSync } from "fs";
 import { sync } from "glob";
 import { join } from "path";
+import { getEsbuildOptions } from "../../utils/esbuild";
 import { getRuntimeConfig, RuntimeConfig } from "../../utils/runtimeConfig";
 
 const bundle = (
@@ -24,16 +25,7 @@ const bundle = (
 
   writeFileSync(join(outDir, "functions.json"), JSON.stringify(runtimeConfigs, null, 2));
   runtimeConfigs.forEach(config => {
-    buildSync({
-      entryPoints: [config.file],
-      absWorkingDir: process.cwd(),
-      format: "cjs",
-      bundle: true,
-      platform: "node",
-      outfile: join(outDir, `functions/${config.name}/index.js`),
-      sourcemap: "both",
-      ...esbuildOptions,
-    });
+    buildSync(getEsbuildOptions(config, outDir, esbuildOptions));
   });
 };
 

--- a/build/esbuild/bundle.ts
+++ b/build/esbuild/bundle.ts
@@ -1,8 +1,8 @@
-import ts from "typescript";
-import { sync } from "glob";
-import { readFileSync, writeFileSync } from "fs";
 import { BuildOptions, buildSync } from "esbuild";
-import { join, relative } from "path";
+import { writeFileSync } from "fs";
+import { sync } from "glob";
+import { join } from "path";
+import { getRuntimeConfig, RuntimeConfig } from "../../utils/runtimeConfig";
 
 const bundle = (
   dir: string,
@@ -12,26 +12,13 @@ const bundle = (
 ) => {
   const files = sync(join(dir, "**/*.ts"));
 
-  let runtimeConfig: any = null;
-  const runtimeConfigs: any[] = [];
+  const runtimeConfigs: RuntimeConfig[] = [];
 
   files.forEach(file => {
-    const fileContents = readFileSync(file);
-    const sourceFile = ts.createSourceFile(
-      "temp.ts",
-      fileContents.toString(),
-      ts.ScriptTarget.Latest,
-    );
+    const runtimeConfig = getRuntimeConfig(file, environment);
 
-    runtimeConfig = detectRuntimeConfig(sourceFile);
-
-    if (runtimeConfig !== null) {
-      runtimeConfig = applyEnvironmentOverrides(environment, runtimeConfig);
-      runtimeConfigs.push({
-        file,
-        name: generateFunctionName(file),
-        ...runtimeConfig,
-      });
+    if (runtimeConfig !== undefined) {
+      runtimeConfigs.push(runtimeConfig);
     }
   });
 
@@ -49,99 +36,5 @@ const bundle = (
     });
   });
 };
+
 export default bundle;
-
-function generateFunctionName(file: string) {
-  return relative(process.cwd(), file)
-    .replace(/(src|index|functions|function|\.ts)/g, "")
-    .replace(/^\//, "")
-    .replace(/\/$/, "")
-    .replace(/[\/_]/g, "-")
-    .replace(/[-]{2,}/g, "-")
-    .replace(/^[-]+/, "")
-    .replace(/[-]+$/, "");
-}
-
-function applyEnvironmentOverrides(
-  environment: string | undefined,
-  runtimeConfig: Record<string, unknown>,
-) {
-  if (environment === undefined) return runtimeConfig;
-
-  const { environmentOverrides, ...rest } = runtimeConfig;
-
-  if (!isObjectLike(environmentOverrides)) return { ...rest };
-
-  const overrides = environmentOverrides[environment];
-
-  if (!isObjectLike(overrides)) return { ...rest };
-
-  return { ...rest, ...overrides };
-}
-
-function detectRuntimeConfig(node: ts.Node) {
-  let runtimeConfig = null;
-  if (node.kind === ts.SyntaxKind.SourceFile) {
-    const sourceFile = node as ts.SourceFile;
-    sourceFile.statements.forEach(statement => {
-      if (statement.kind !== ts.SyntaxKind.FirstStatement) {
-        return;
-      }
-      const firstStatement = statement as ts.VariableStatement;
-      firstStatement.declarationList.declarations.forEach(declaration => {
-        if (declaration.name.kind !== ts.SyntaxKind.Identifier) {
-          return;
-        }
-        if (declaration.name.escapedText === "runtimeConfig") {
-          runtimeConfig = mapObjectLiteral(declaration.initializer as ts.ObjectLiteralExpression);
-        }
-      });
-    });
-  }
-
-  return runtimeConfig;
-}
-
-function mapObjectLiteral(node: ts.ObjectLiteralExpression) {
-  return node.properties.reduce((accumulator, currentValue) => {
-    const res = readObjectNode(currentValue);
-    return { ...accumulator, ...res };
-  }, {});
-}
-
-function readObjectNode(node: ts.ObjectLiteralElement) {
-  if (node.kind !== ts.SyntaxKind.PropertyAssignment) {
-    return;
-  }
-
-  const mappedObject: any = {};
-  const property = node as ts.PropertyAssignment;
-  const propertyName = property.name as ts.Identifier;
-  const idx = propertyName.escapedText.toString();
-  mappedObject[idx] = mapNode(property.initializer);
-  return mappedObject;
-}
-
-function mapNode(node: ts.Node): any {
-  switch (node.kind) {
-    case ts.SyntaxKind.NumericLiteral:
-      return Number((node as ts.NumericLiteral).text);
-    case ts.SyntaxKind.TrueKeyword:
-      return true;
-    case ts.SyntaxKind.FalseKeyword:
-      return false;
-    case ts.SyntaxKind.StringLiteral:
-      return (node as ts.StringLiteral).text;
-    case ts.SyntaxKind.ObjectLiteralExpression:
-      return mapObjectLiteral(node as ts.ObjectLiteralExpression);
-    case ts.SyntaxKind.ArrayLiteralExpression:
-      const array = node as ts.ArrayLiteralExpression;
-      return array.elements.map(mapNode);
-  }
-
-  return "UNSUPPORTED";
-}
-
-function isObjectLike(value: unknown): value is Partial<Record<string | number | symbol, unknown>> {
-  return typeof value === "object" && value !== null;
-}

--- a/cli/run.ts
+++ b/cli/run.ts
@@ -1,0 +1,61 @@
+import arg, { ArgError } from "arg";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { cliCommand } from "../bin/entrypoint";
+import { printAndExit } from "./utils";
+import run from "../run";
+
+const argumentSchema = {
+  "-h": "--help",
+  "--help": Boolean,
+
+  "--env": String,
+
+  "-p": "--port",
+  "--port": Number,
+};
+
+export const cmdRun: cliCommand = argv => {
+  let args: arg.Result<typeof argumentSchema>;
+
+  try {
+    args = arg(argumentSchema, { argv });
+  } catch (error) {
+    if (error instanceof ArgError && error.code === "ARG_UNKNOWN_OPTION") {
+      return printAndExit(error.message);
+    }
+
+    throw error;
+  }
+
+  if (args["--help"]) {
+    return printAndExit(
+      `
+      Usage
+        $ cloud-seed run <path/to/function.ts> --env=<environment>
+      Options
+        --env=<environment>           Use the configuration from the specified environment in cloud-seed.json
+        --help, -h                    Displays this message
+        --port=<number>, -p=<number>  Specify the port to run the environment on (default: 3000)`,
+      0,
+    );
+  }
+
+  const environment = args["--env"];
+  if (!environment) {
+    return printAndExit("> Environment is required. Please set the --env flag.");
+  }
+
+  const port = args["--port"] ?? 3000;
+
+  const sourceFile = args._[0];
+  if (!existsSync(resolve(sourceFile))) {
+    return printAndExit(`> No such file exists: ${sourceFile}`);
+  }
+
+  return run({
+    environment,
+    port,
+    sourceFile,
+  });
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,5 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
-  testPathIgnorePatterns: [".gen", "node_modules"],
+  testPathIgnorePatterns: [".gen", "node_modules", "dist"],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@space48/cloud-seed",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@space48/cloud-seed",
-      "version": "3.0.0",
+      "version": "4.0.0",
       "license": "ISC",
       "dependencies": {
         "@cdktf/provider-archive": "^10.3.0",
@@ -25,6 +25,7 @@
       "devDependencies": {
         "@jest/globals": "^29.7.0",
         "@tsconfig/node20": "^20.1.4",
+        "@types/jest": "^29.5.14",
         "@types/node": "^20.10.0",
         "eslint": "^9.16.0",
         "eslint-config-prettier": "^9.1.0",
@@ -3173,6 +3174,17 @@
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "node_modules/@types/json-schema": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "devDependencies": {
     "@jest/globals": "^29.7.0",
     "@tsconfig/node20": "^20.1.4",
+    "@types/jest": "^29.5.14",
     "@types/node": "^20.10.0",
     "eslint": "^9.16.0",
     "eslint-config-prettier": "^9.1.0",

--- a/run/DevelopmentServer/GcpServer.ts
+++ b/run/DevelopmentServer/GcpServer.ts
@@ -1,0 +1,94 @@
+import { ChildProcess, spawn } from "node:child_process";
+import { BaseConfig } from "../../utils/rootConfig";
+import { RuntimeConfig } from "../../utils/runtimeConfig";
+import { DevelopmentServer } from "./types";
+
+export default class GcpServer implements DevelopmentServer {
+  private sourceFile: string;
+  private signatureType: string;
+  private port: string;
+  private environmentVariables: { [key: string]: string | undefined } = {};
+
+  private serverProcess: ChildProcess | undefined;
+
+  constructor(
+    projectConfig: BaseConfig,
+    functionConfig: RuntimeConfig,
+    compiledFile: string,
+    port: number,
+    environment: string,
+  ) {
+    this.sourceFile = compiledFile;
+    this.signatureType = getFunctionSignatureType(functionConfig);
+    this.port = port.toString();
+    this.environmentVariables = getFunctionEnvironmentVariables(projectConfig, environment);
+  }
+
+  public up() {
+    if (this.serverProcess === undefined) {
+      this.startServerProcess();
+    } else {
+      this.serverProcess.on("exit", () => {
+        setTimeout(this.startServerProcess.bind(this), 500);
+      });
+      this.serverProcess.kill("SIGINT");
+    }
+  }
+
+  public down() {
+    if (this.serverProcess !== undefined) {
+      this.serverProcess.on("exit", () => {
+        this.serverProcess = undefined;
+      });
+      this.serverProcess.kill("SIGINT");
+    }
+  }
+
+  public isRunning() {
+    return this.serverProcess !== undefined;
+  }
+
+  private startServerProcess() {
+    this.serverProcess = spawn(
+      "npx",
+      [
+        "-y",
+        "@google-cloud/functions-framework",
+        "--source",
+        this.sourceFile,
+        "--target",
+        "default",
+        "--signature-type",
+        this.signatureType,
+        "--port",
+        this.port,
+      ],
+      {
+        env: this.environmentVariables,
+        stdio: "inherit",
+      },
+    );
+  }
+}
+
+function getFunctionSignatureType(functionConfig: RuntimeConfig): "http" | "event" | "cloudevent" {
+  switch (functionConfig.type) {
+    case "event":
+    case "schedule":
+    case "firestore":
+    case "storage":
+      return "cloudevent";
+    default:
+      return "http";
+  }
+}
+
+function getFunctionEnvironmentVariables(projectConfig: BaseConfig, environment: string) {
+  return {
+    CLOUD_SEED_ENVIRONMENT: environment,
+    CLOUD_SEED_PROJECT: projectConfig.cloud.gcp.project,
+    CLOUD_SEED_REGION: projectConfig.cloud.gcp.region,
+    ...projectConfig.runtimeEnvironmentVariables,
+    ...process.env,
+  };
+}

--- a/run/DevelopmentServer/index.ts
+++ b/run/DevelopmentServer/index.ts
@@ -1,0 +1,21 @@
+import { BaseConfig } from "../../utils/rootConfig";
+import { RuntimeConfig } from "../../utils/runtimeConfig";
+import GcpServer from "./GcpServer";
+import { DevelopmentServer } from "./types";
+
+export function getDevelopmentServer(
+  projectConfig: BaseConfig,
+  functionConfig: RuntimeConfig,
+  compiledFile: string,
+  port: number,
+  environment: string,
+): DevelopmentServer {
+  switch (functionConfig.cloud) {
+    case "gcp":
+      return new GcpServer(projectConfig, functionConfig, compiledFile, port, environment);
+    default:
+      throw new Error(
+        `The development server does not support running functions using the "${functionConfig.cloud}" cloud at this time.`,
+      );
+  }
+}

--- a/run/DevelopmentServer/types.ts
+++ b/run/DevelopmentServer/types.ts
@@ -1,0 +1,16 @@
+export interface DevelopmentServer {
+  /**
+   * Start the development server, or restart it if it's already running.
+   */
+  up(): void;
+
+  /**
+   * Stop the development server.
+   */
+  down(): void;
+
+  /**
+   * Check if the server is currently running.
+   */
+  isRunning(): boolean;
+}

--- a/run/index.ts
+++ b/run/index.ts
@@ -1,0 +1,63 @@
+import { context } from "esbuild";
+import { mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { printAndExit } from "../cli/utils";
+import { getEsbuildOptions } from "../utils/esbuild";
+import { getRootConfig } from "../utils/rootConfig";
+import { getRuntimeConfig } from "../utils/runtimeConfig";
+import { getDevelopmentServer } from "./DevelopmentServer";
+
+export type RunOptions = {
+  environment: string;
+  port: number;
+  sourceFile: string;
+};
+
+export default ({ environment, port, sourceFile }: RunOptions): void => {
+  const projectConfig = getRootConfig(dirname(sourceFile), { environment });
+  const functionConfig = getRuntimeConfig(sourceFile, environment);
+
+  if (functionConfig === undefined) {
+    printAndExit(
+      `> Provided source file "${sourceFile}" does not include a valid function runtime configuration!`,
+    );
+
+    return;
+  }
+
+  const outputDirectory = resolve(projectConfig.buildConfig.outDir);
+  mkdirSync(outputDirectory, { recursive: true });
+
+  const esbuildOptions = getEsbuildOptions(functionConfig, outputDirectory, {
+    ...projectConfig.buildConfig.esbuildOptions,
+    plugins: [
+      ...(projectConfig.buildConfig.esbuildOptions?.plugins ?? []),
+      {
+        name: "Development Server",
+        setup(build) {
+          const compiledFile = build.initialOptions.outfile;
+          if (compiledFile === undefined) return;
+
+          const developmentServer = getDevelopmentServer(
+            projectConfig,
+            functionConfig,
+            compiledFile,
+            port,
+            environment,
+          );
+
+          build.onEnd(result => {
+            if (result.errors.length > 0) return;
+
+            const action = developmentServer.isRunning() ? "Restarting" : "Starting";
+
+            console.log(`Build completed successfully. ${action} the development server...`);
+            developmentServer.up();
+          });
+        },
+      },
+    ],
+  });
+
+  context(esbuildOptions).then(context => context.watch());
+};

--- a/utils/esbuild.ts
+++ b/utils/esbuild.ts
@@ -1,0 +1,20 @@
+import { BuildOptions } from "esbuild";
+import { join } from "node:path";
+import { RuntimeConfig } from "./runtimeConfig";
+
+export function getEsbuildOptions(
+  functionConfig: RuntimeConfig,
+  outputDirectory: string,
+  additionalOptions?: Partial<BuildOptions>,
+): Partial<BuildOptions> {
+  return {
+    entryPoints: [functionConfig.file],
+    absWorkingDir: process.cwd(), // We should probably infer the working directory from the cloudseed.json file
+    format: "cjs",
+    bundle: true,
+    platform: "node",
+    outfile: join(outputDirectory, `functions/${functionConfig.name}/index.js`),
+    sourcemap: "both",
+    ...additionalOptions,
+  };
+}

--- a/utils/rootConfig.test.ts
+++ b/utils/rootConfig.test.ts
@@ -1,0 +1,391 @@
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+import { getRootConfig, RootConfig } from "./rootConfig";
+import { DeepPartial } from "./types";
+
+jest.mock("fs");
+jest.mock("path");
+
+describe("getRootConfig", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return the default config options when cloudseed.json does not exist and no overrides are provided", () => {
+    const workingDirectory = "/project";
+    const cliOptions = { environment: "testing" };
+
+    (resolve as jest.Mock).mockImplementation((...args) => args[0]);
+    (existsSync as jest.Mock).mockReturnValue(false);
+
+    const result = getRootConfig(workingDirectory, cliOptions);
+
+    expect(result).toEqual({
+      cloud: {
+        gcp: {
+          project: "",
+          region: "europe-west2",
+          sourceCodeStorage: {
+            bucket: {
+              name: "",
+            },
+          },
+        },
+      },
+      tfConfig: {
+        backend: {
+          type: "local",
+          backendOptions: { path: ".build" },
+        },
+      },
+      buildConfig: {
+        dir: "src",
+        outDir: ".build",
+        esbuildOptions: undefined,
+      },
+      runtimeEnvironmentVariables: {},
+      secretVariableNames: undefined,
+    });
+  });
+
+  it("should return the config from cloudseed.json if its found in the working directory", () => {
+    const workingDirectory = "/project";
+    const cliOptions = { environment: "testing" };
+    const configFileContent = JSON.stringify({
+      default: {
+        cloud: {
+          gcp: {
+            project: "default-project",
+            region: "default-region",
+          },
+        },
+        tfConfig: {
+          backend: {
+            type: "local",
+            backendOptions: { path: "default-backend-path" },
+          },
+        },
+        buildConfig: {
+          dir: "default-src",
+          outDir: "default-build",
+        },
+      },
+    } satisfies DeepPartial<RootConfig>);
+
+    (resolve as jest.Mock).mockImplementation((...args) => args[0]);
+    (existsSync as jest.Mock).mockReturnValueOnce(true);
+    (readFileSync as jest.Mock).mockReturnValueOnce(Buffer.from(configFileContent));
+
+    const result = getRootConfig(workingDirectory, cliOptions);
+
+    expect(result).toEqual({
+      cloud: {
+        gcp: {
+          project: "default-project",
+          region: "default-region",
+          sourceCodeStorage: {
+            bucket: {
+              name: "",
+            },
+          },
+        },
+      },
+      tfConfig: {
+        backend: {
+          type: "local",
+          backendOptions: { path: "default-backend-path" },
+        },
+      },
+      buildConfig: {
+        dir: "default-src",
+        outDir: "default-build",
+        esbuildOptions: undefined,
+      },
+      runtimeEnvironmentVariables: {},
+      secretVariableNames: undefined,
+    });
+  });
+
+  it("should return the config from cloudseed.json if its found in the parent directory", () => {
+    const workingDirectory = "/path/to/project";
+    const cliOptions = { environment: "testing" };
+    const configFileContent = JSON.stringify({
+      default: {
+        cloud: {
+          gcp: {
+            project: "default-project",
+            region: "default-region",
+          },
+        },
+        tfConfig: {
+          backend: {
+            type: "local",
+            backendOptions: { path: "default-backend-path" },
+          },
+        },
+        buildConfig: {
+          dir: "default-src",
+          outDir: "default-build",
+        },
+      },
+    } satisfies DeepPartial<RootConfig>);
+
+    (resolve as jest.Mock).mockImplementation((...args) => args[0]);
+    (existsSync as jest.Mock).mockReturnValueOnce(false).mockReturnValueOnce(true);
+    (readFileSync as jest.Mock).mockReturnValueOnce(Buffer.from(configFileContent));
+
+    const result = getRootConfig(workingDirectory, cliOptions);
+
+    expect(result).toEqual({
+      cloud: {
+        gcp: {
+          project: "default-project",
+          region: "default-region",
+          sourceCodeStorage: {
+            bucket: {
+              name: "",
+            },
+          },
+        },
+      },
+      tfConfig: {
+        backend: {
+          type: "local",
+          backendOptions: { path: "default-backend-path" },
+        },
+      },
+      buildConfig: {
+        dir: "default-src",
+        outDir: "default-build",
+        esbuildOptions: undefined,
+      },
+      runtimeEnvironmentVariables: {},
+      secretVariableNames: undefined,
+    });
+  });
+
+  it("should return the default config options when cloudseed.json is empty or invalid", () => {
+    const workingDirectory = "/path/to/project";
+    const cliOptions = { environment: "testing" };
+    const configFileContent = "";
+
+    (resolve as jest.Mock).mockImplementation((...args) => args[0]);
+    (existsSync as jest.Mock).mockReturnValueOnce(true);
+    (readFileSync as jest.Mock).mockReturnValueOnce(Buffer.from(configFileContent));
+
+    const result = getRootConfig(workingDirectory, cliOptions);
+
+    expect(result).toEqual({
+      cloud: {
+        gcp: {
+          project: "",
+          region: "europe-west2",
+          sourceCodeStorage: {
+            bucket: {
+              name: "",
+            },
+          },
+        },
+      },
+      tfConfig: {
+        backend: {
+          type: "local",
+          backendOptions: { path: ".build" },
+        },
+      },
+      buildConfig: {
+        dir: "src",
+        outDir: ".build",
+        esbuildOptions: undefined,
+      },
+      runtimeEnvironmentVariables: {},
+      secretVariableNames: undefined,
+    });
+  });
+
+  it("should return the root config options when no environment-specific overrides are specified", () => {
+    const workingDirectory = "/project";
+    const cliOptions = { environment: "testing" };
+    const configFileContent = JSON.stringify({
+      default: {
+        cloud: {
+          gcp: {
+            project: "default-project",
+            region: "default-region",
+          },
+        },
+        tfConfig: {
+          backend: {
+            type: "local",
+            backendOptions: { path: "default-backend-path" },
+          },
+        },
+        buildConfig: {
+          dir: "default-src",
+          outDir: "default-build",
+        },
+      },
+    } satisfies DeepPartial<RootConfig>);
+
+    (resolve as jest.Mock).mockImplementation((...args) => args[0]);
+    (existsSync as jest.Mock).mockReturnValueOnce(true);
+    (readFileSync as jest.Mock).mockReturnValueOnce(Buffer.from(configFileContent));
+
+    const result = getRootConfig(workingDirectory, cliOptions);
+
+    expect(result).toEqual({
+      cloud: {
+        gcp: {
+          project: "default-project",
+          region: "default-region",
+          sourceCodeStorage: {
+            bucket: {
+              name: "",
+            },
+          },
+        },
+      },
+      tfConfig: {
+        backend: {
+          type: "local",
+          backendOptions: { path: "default-backend-path" },
+        },
+      },
+      buildConfig: {
+        dir: "default-src",
+        outDir: "default-build",
+        esbuildOptions: undefined,
+      },
+      runtimeEnvironmentVariables: {},
+      secretVariableNames: undefined,
+    });
+  });
+
+  it("should override the root config options with environment-specific overrides", () => {
+    const workingDirectory = "/project";
+    const cliOptions = { environment: "testing" };
+    const configFileContent = JSON.stringify({
+      default: {
+        cloud: {
+          gcp: {
+            project: "default-project",
+            region: "default-region",
+          },
+        },
+        tfConfig: {
+          backend: {
+            type: "local",
+            backendOptions: { path: "default-backend-path" },
+          },
+        },
+        buildConfig: {
+          dir: "default-src",
+          outDir: "default-build",
+        },
+      },
+      environmentOverrides: {
+        testing: {
+          cloud: {
+            gcp: {
+              project: "testing-project",
+              region: "testing-region",
+            },
+          },
+          buildConfig: {
+            dir: "testing-src",
+            outDir: "testing-build",
+          },
+        },
+      },
+    } satisfies DeepPartial<RootConfig>);
+
+    (resolve as jest.Mock).mockImplementation((...args) => args[0]);
+    (existsSync as jest.Mock).mockReturnValueOnce(true);
+    (readFileSync as jest.Mock).mockReturnValueOnce(Buffer.from(configFileContent));
+
+    const result = getRootConfig(workingDirectory, cliOptions);
+
+    expect(result).toEqual({
+      cloud: {
+        gcp: {
+          project: "testing-project",
+          region: "testing-region",
+          sourceCodeStorage: {
+            bucket: {
+              name: "",
+            },
+          },
+        },
+      },
+      tfConfig: {
+        backend: {
+          type: "local",
+          backendOptions: { path: "default-backend-path" },
+        },
+      },
+      buildConfig: {
+        dir: "testing-src",
+        outDir: "testing-build",
+        esbuildOptions: undefined,
+      },
+      runtimeEnvironmentVariables: {},
+      secretVariableNames: undefined,
+    });
+  });
+
+  it("should use CLI options to override config values", () => {
+    const workingDirectory = "/project";
+    const cliOptions = {
+      environment: "testing",
+      srcDir: "cli-src",
+      outDir: "cli-build",
+    };
+    const configFileContent = JSON.stringify({
+      default: {
+        cloud: {
+          gcp: {
+            project: "default-project",
+            region: "default-region",
+          },
+        },
+        buildConfig: {
+          dir: "default-src",
+          outDir: "default-build",
+        },
+      },
+    } satisfies DeepPartial<RootConfig>);
+
+    (resolve as jest.Mock).mockImplementation((...args) => args[0]);
+    (existsSync as jest.Mock).mockReturnValueOnce(true);
+    (readFileSync as jest.Mock).mockReturnValueOnce(Buffer.from(configFileContent));
+
+    const result = getRootConfig(workingDirectory, cliOptions);
+
+    expect(result).toEqual({
+      cloud: {
+        gcp: {
+          project: "default-project",
+          region: "default-region",
+          sourceCodeStorage: {
+            bucket: {
+              name: "",
+            },
+          },
+        },
+      },
+      tfConfig: {
+        backend: {
+          type: "local",
+          backendOptions: { path: "cli-build" },
+        },
+      },
+      buildConfig: {
+        dir: "cli-src",
+        outDir: "cli-build",
+        esbuildOptions: undefined,
+      },
+      runtimeEnvironmentVariables: {},
+      secretVariableNames: undefined,
+    });
+  });
+});

--- a/utils/rootConfig.ts
+++ b/utils/rootConfig.ts
@@ -1,17 +1,8 @@
 import { GcsBackendConfig, LocalBackendConfig, S3BackendConfig } from "cdktf";
 import { BuildOptions } from "esbuild";
 import { existsSync, readFileSync } from "fs";
-import { join, resolve } from "path";
+import { dirname, join, resolve } from "path";
 import { DeepPartial } from "./types";
-
-export function getRootConfig(rootDir: string): DeepPartial<RootConfig> {
-  const rootConfPath = resolve(join(rootDir, "cloudseed.json"));
-  const rootConf = existsSync(rootConfPath) ? readFileSync(rootConfPath) : null;
-  if (rootConf === null) {
-    return {};
-  }
-  return JSON.parse(rootConf.toString("utf8"));
-}
 
 export interface BaseConfig {
   cloud: {
@@ -55,5 +46,105 @@ export interface RootConfig {
   default?: BaseConfig;
   environmentOverrides?: {
     [key: string]: Partial<BaseConfig>;
+  };
+}
+
+export interface CliOptions {
+  srcDir?: string;
+  outDir?: string;
+  environment: string;
+}
+
+export function getRootConfig(workingDirectory: string, cliOptions: CliOptions): BaseConfig {
+  const rootConfig = discoverRootConfig(workingDirectory);
+
+  return parseConfig(rootConfig, cliOptions);
+}
+
+function discoverRootConfig(startingDirectory: string): DeepPartial<RootConfig> {
+  let previousDirectory: string | undefined;
+  let currentDirectory = startingDirectory;
+
+  while (currentDirectory !== previousDirectory) {
+    const configPath = resolve(join(currentDirectory, "cloudseed.json"));
+
+    if (existsSync(configPath)) {
+      const config = readFileSync(configPath) ?? undefined;
+
+      try {
+        return config !== undefined ? JSON.parse(config.toString("utf-8")) : {};
+      } catch {
+        return {};
+      }
+    }
+
+    previousDirectory = currentDirectory;
+    currentDirectory = dirname(currentDirectory);
+  }
+
+  return {};
+}
+
+function parseConfig(rootConfig: DeepPartial<RootConfig>, cliOptions: CliOptions): BaseConfig {
+  const environmentConfig = rootConfig.environmentOverrides?.[cliOptions.environment] ?? undefined;
+  const defaultConfig = rootConfig.default;
+
+  const sourceDirectory = resolve(
+    cliOptions.srcDir ??
+      environmentConfig?.buildConfig?.dir ??
+      defaultConfig?.buildConfig?.dir ??
+      "src",
+  );
+
+  const outputDirectory = resolve(
+    cliOptions.outDir ??
+      environmentConfig?.buildConfig?.outDir ??
+      defaultConfig?.buildConfig?.outDir ??
+      ".build",
+  );
+
+  return {
+    cloud: {
+      gcp: {
+        project: environmentConfig?.cloud?.gcp?.project ?? defaultConfig?.cloud?.gcp?.project ?? "",
+        region:
+          environmentConfig?.cloud?.gcp?.region ??
+          defaultConfig?.cloud?.gcp?.region ??
+          "europe-west2",
+        sourceCodeStorage: {
+          bucket: {
+            name:
+              environmentConfig?.cloud?.gcp?.sourceCodeStorage?.bucket?.name ??
+              defaultConfig?.cloud?.gcp?.sourceCodeStorage?.bucket?.name ??
+              "",
+          },
+        },
+      },
+    },
+    tfConfig: {
+      backend: ((environmentConfig?.tfConfig?.backend ??
+        defaultConfig?.tfConfig?.backend) as BaseConfig["tfConfig"]["backend"]) ?? {
+        type: "local",
+        backendOptions: { path: outputDirectory },
+      },
+    },
+    buildConfig: {
+      dir: sourceDirectory,
+      outDir: outputDirectory,
+      esbuildOptions: (environmentConfig?.buildConfig?.esbuildOptions ??
+        defaultConfig?.buildConfig?.esbuildOptions) as BuildOptions | undefined,
+    },
+    runtimeEnvironmentVariables: Object.fromEntries(
+      Object.entries(
+        environmentConfig?.runtimeEnvironmentVariables ??
+          defaultConfig?.runtimeEnvironmentVariables ??
+          {},
+      )
+        .map(([key, value]) => [key, typeof value === "string" ? value : ""])
+        .filter(([, value]) => value.length),
+    ),
+    secretVariableNames: (
+      environmentConfig?.secretVariableNames ?? defaultConfig?.secretVariableNames
+    )?.filter((name): name is string => typeof name === "string"),
   };
 }

--- a/utils/runtimeConfig.test.ts
+++ b/utils/runtimeConfig.test.ts
@@ -1,0 +1,197 @@
+import { readFileSync } from "node:fs";
+import { getRuntimeConfig } from "./runtimeConfig";
+
+jest.mock("node:fs");
+
+describe("getRuntimeConfig", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return undefined where the file does not contain a runtimeConfig", () => {
+    const fileName = "src/path/to/function.ts";
+    const fileContents = `
+      const myFunc = (req: Request, res: Response) => {
+        res.sendStatus(200);
+      };
+
+      export default myFunc;
+    `;
+
+    (readFileSync as jest.Mock).mockReturnValueOnce(Buffer.from(fileContents));
+
+    const result = getRuntimeConfig(fileName);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined when the file does not contain a top-level runtimeConfig", () => {
+    const fileName = "src/path/to/function.ts";
+    const fileContents = `
+      const myFunc = (req: Request, res: Response) => {
+        const runtimeConfig = {
+          cloud: "gcp",
+          runtime: "nodejs20",
+          type: "http",
+          public: true,
+        };
+
+        res.sendStatus(200);
+      };
+
+      export default myFunc;
+    `;
+
+    (readFileSync as jest.Mock).mockReturnValueOnce(Buffer.from(fileContents));
+
+    const result = getRuntimeConfig(fileName);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined if the provided file does not exist", () => {
+    const fileName = "src/path/to/function.ts";
+
+    (readFileSync as jest.Mock).mockImplementation(() => {
+      throw new Error("File not found");
+    });
+
+    const result = getRuntimeConfig(fileName);
+
+    expect(result).toBeUndefined();
+  });
+
+  it("should return the runtimeConfig defined in the provided file", () => {
+    const fileName = "src/path/to/function.ts";
+    const fileContents = `
+      import type { GcpConfig } from "@space48/cloud-seed";
+
+      const myFunc = (req: Request, res: Response) => {
+        res.sendStatus(200);
+      };
+
+      export default myFunc;
+
+      export const runtimeConfig: GcpConfig = {
+        cloud: "gcp",
+        name: "my-test-function",
+        runtime: "nodejs20",
+        type: "http",
+        public: true,
+      };
+    `;
+
+    (readFileSync as jest.Mock).mockReturnValueOnce(Buffer.from(fileContents));
+
+    const result = getRuntimeConfig(fileName);
+
+    expect(result).toEqual({
+      file: "src/path/to/function.ts",
+      name: "my-test-function",
+      cloud: "gcp",
+      runtime: "nodejs20",
+      type: "http",
+      public: true,
+    });
+  });
+
+  it("should apply environment-specific overrides to the runtimeConfig", () => {
+    const fileName = "src/path/to/function.ts";
+    const fileContents = `
+      import type { GcpConfig } from "@space48/cloud-seed";
+
+      const myFunc = (req: Request, res: Response) => {
+        res.sendStatus(200);
+      };
+
+      export default myFunc;
+
+      export const runtimeConfig: GcpConfig = {
+        cloud: "gcp",
+        runtime: "nodejs20",
+        name: "my-test-function",
+        type: "http",
+        public: true,
+        timeout: 300,
+        environmentOverrides: {
+          testing: {
+            timeout: 600,
+          },
+        },
+      };
+    `;
+
+    (readFileSync as jest.Mock).mockReturnValueOnce(Buffer.from(fileContents));
+
+    const result = getRuntimeConfig(fileName, "testing");
+
+    expect(result).toEqual({
+      file: "src/path/to/function.ts",
+      name: "my-test-function",
+      cloud: "gcp",
+      runtime: "nodejs20",
+      type: "http",
+      public: true,
+      timeout: 600,
+    });
+  });
+
+  it("should correctly parse all supported configuration value types", () => {
+    const fileName = "src/path/to/function.ts";
+    const fileContents = `
+      export const runtimeConfig = {
+        name: "my-test-function",
+        stringKey: "stringValue",
+        numberKeyInteger: 1,
+        numberKeyDecimal: 9.999,
+        booleanKeyTrue: true,
+        booleanKeyFalse: false,
+        objectKey: {
+          stringKey: "stringValue",
+          objectKey: {
+            numberKey: 100,
+          },
+          arrayKey: ["stringValue", 100, true, false, { stringKey: "stringValue" }],
+        },
+        arrayKey: ["stringValue", 100, true, { stringKey: "stringValue" }, [ "stringValue", 5, false]],
+      };
+    `;
+
+    (readFileSync as jest.Mock).mockReturnValueOnce(Buffer.from(fileContents));
+
+    const result = getRuntimeConfig(fileName);
+
+    expect(result).toEqual({
+      file: "src/path/to/function.ts",
+      name: "my-test-function",
+      stringKey: "stringValue",
+      numberKeyInteger: 1,
+      numberKeyDecimal: 9.999,
+      booleanKeyTrue: true,
+      booleanKeyFalse: false,
+      objectKey: {
+        stringKey: "stringValue",
+        objectKey: {
+          numberKey: 100,
+        },
+        arrayKey: ["stringValue", 100, true, false, { stringKey: "stringValue" }],
+      },
+      arrayKey: ["stringValue", 100, true, { stringKey: "stringValue" }, ["stringValue", 5, false]],
+    });
+  });
+
+  it("should generate the function name from the source file name if a name is not provided", () => {
+    const fileName = "src/my-integration//functions/webhook-receiver/index.ts";
+    const fileContents = `
+      export const runtimeConfig = {
+        exampleKey: "exampleValue",
+      };
+    `;
+
+    (readFileSync as jest.Mock).mockReturnValueOnce(Buffer.from(fileContents));
+
+    const result = getRuntimeConfig(fileName);
+
+    expect(result?.name).toEqual("my-integration-webhook-receiver");
+  });
+});

--- a/utils/runtimeConfig.ts
+++ b/utils/runtimeConfig.ts
@@ -1,0 +1,144 @@
+import { readFileSync } from "node:fs";
+import { relative } from "node:path";
+import ts from "typescript";
+
+export type RuntimeConfig = {
+  file: string;
+  name: string;
+} & RuntimeConfigProperties;
+
+type RuntimeConfigProperties = {
+  [key: string]: RuntimeConfigValue | undefined;
+};
+
+type RuntimeConfigValue =
+  | string
+  | number
+  | boolean
+  | RuntimeConfigValue[]
+  | { [key: string]: RuntimeConfigValue | undefined };
+
+export function getRuntimeConfig(
+  fileName: string,
+  environment?: string,
+): RuntimeConfig | undefined {
+  let fileContents: ReturnType<typeof readFileSync>;
+  try {
+    fileContents = readFileSync(fileName);
+  } catch {
+    return undefined;
+  }
+
+  const sourceFile = ts.createSourceFile(
+    "temp.ts",
+    fileContents.toString(),
+    ts.ScriptTarget.Latest,
+  );
+
+  const runtimeConfig = detectRuntimeConfig(sourceFile);
+
+  if (runtimeConfig === undefined) return undefined;
+
+  return {
+    file: fileName,
+    name: generateFunctionName(fileName),
+    ...applyEnvironmentOverrides(runtimeConfig, environment),
+  };
+}
+
+function detectRuntimeConfig(node: ts.Node): RuntimeConfigProperties | undefined {
+  if (node.kind !== ts.SyntaxKind.SourceFile) return undefined;
+
+  const sourceFile = node as ts.SourceFile;
+
+  for (const statement of sourceFile.statements) {
+    if (statement.kind !== ts.SyntaxKind.VariableStatement) continue;
+
+    const variableStatement = statement as ts.VariableStatement;
+
+    for (const declaration of variableStatement.declarationList.declarations) {
+      if (declaration.name.kind !== ts.SyntaxKind.Identifier) continue;
+      if (declaration.name.escapedText !== "runtimeConfig") continue;
+
+      // We are assuming here that the declaration of runtimeConfig contains an object
+      // literal expression. We should probably validate that and report a warning if
+      // it's not an object literal, instead of potentially causing a runtime error.
+      return mapObjectLiteral(declaration.initializer as ts.ObjectLiteralExpression);
+    }
+  }
+}
+
+function mapObjectLiteral(node: ts.ObjectLiteralExpression) {
+  return node.properties.reduce<{ [key: string]: RuntimeConfigValue | undefined }>(
+    (accumulator, currentValue) => {
+      return { ...accumulator, ...mapObjectProperty(currentValue) };
+    },
+    {},
+  );
+}
+
+function mapObjectProperty(node: ts.ObjectLiteralElement) {
+  if (node.kind !== ts.SyntaxKind.PropertyAssignment) return;
+
+  const propertyAssignment = node as ts.PropertyAssignment;
+
+  // We're assuming that runtime config keys are all identifiers here. We should probably
+  // validate that and report a warning instead of potentially causing a runtime error.
+  const propertyName = (propertyAssignment.name as ts.Identifier).escapedText.toString();
+
+  return {
+    [propertyName]: mapValue(propertyAssignment.initializer),
+  };
+}
+
+function mapValue(node: ts.Node): RuntimeConfigValue {
+  switch (node.kind) {
+    case ts.SyntaxKind.NumericLiteral:
+      return Number((node as ts.NumericLiteral).text);
+    case ts.SyntaxKind.TrueKeyword:
+      return true;
+    case ts.SyntaxKind.FalseKeyword:
+      return false;
+    case ts.SyntaxKind.StringLiteral:
+      return (node as ts.StringLiteral).text;
+    case ts.SyntaxKind.ObjectLiteralExpression:
+      return mapObjectLiteral(node as ts.ObjectLiteralExpression);
+    case ts.SyntaxKind.ArrayLiteralExpression:
+      return (node as ts.ArrayLiteralExpression).elements.map(mapValue);
+    default:
+      // We should probably raise a warning here instead of using a default string value
+      return "UNSUPPORTED";
+  }
+}
+
+function applyEnvironmentOverrides(
+  runtimeConfig: RuntimeConfigProperties,
+  environment: string | undefined,
+): RuntimeConfigProperties {
+  if (environment === undefined) return runtimeConfig;
+
+  const { environmentOverrides, ...rest } = runtimeConfig;
+
+  if (!isObjectLike(environmentOverrides)) return { ...rest };
+
+  const overrides = environmentOverrides[environment];
+
+  if (!isObjectLike(overrides)) return { ...rest };
+
+  return { ...rest, ...overrides };
+}
+
+function generateFunctionName(fileName: string) {
+  return relative(process.cwd(), fileName)
+    .replace(/(src|index|functions|function|\.ts)/g, "")
+    .replace(/^\//, "")
+    .replace(/\/$/, "")
+    .replace(/[\/_]/g, "-")
+    .replace(/[-]{2,}/g, "-")
+    .replace(/^[-]+/, "")
+    .replace(/[-]+$/, "");
+}
+
+function isObjectLike(value: unknown): value is Partial<Record<string | number | symbol, unknown>> {
+  return typeof value === "object" && value !== null;
+}


### PR DESCRIPTION
### Highlight

This adds a `cloud-seed run` command to run functions locally (one at a time) with automatic rebuilding on changes.

It's a pretty barebones implementation, and can be expanded in the future, but it will hopefully reduce the cycle time on writing functions and improve the developer experience.

### Other changes

- Several utilities have been decoupled from the `build` command and refactored into reusable functions so they can be used by the `run` command. There should be no functional changes how the `build` command works, other than the changes listed in `CHANGELOG.md`.
- Added unit tests to the refactored components, mainly testing that the config files are parsed and interpreted correctly.