### PR TITLE
S48-XX: update firestore event trigger type to document instead of da…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/Space48/cloud-seed/compare/v4.1.0...HEAD)
+## [Unreleased](https://github.com/Space48/cloud-seed/compare/HEAD...v4.1.3)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/Space48/cloud-seed/compare/v4.1.0...HEAD)
 
+### Fixed
+
+- Fixed an "Unsupported" error when deploying `Firestore` functions with `event trigger filter attribute` set to `database` instead of `document`
+
+## [4.1.2](https://github.com/Space48/cloud-seed/compare/v4.1.0...v4.1.2)
+
 ### Added
 
 - Added CONTRIBUTING.md with comprehensive contribution guidelines
@@ -44,7 +50,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated package dependencies
 - Enhanced type safety for environment-specific configurations
-
 
 ## [v3.0.0](https://github.com/Space48/cloud-seed/compare/v2.1.0...v3.0.0)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@space48/cloud-seed",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@space48/cloud-seed",
-      "version": "4.1.2",
+      "version": "4.1.3",
       "license": "MIT",
       "dependencies": {
         "@cdktf/provider-archive": "^10.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@space48/cloud-seed",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Cloud infrastructure automation tool that uses Terraform CDK.",
   "main": "dist/index.js",
   "bin": {

--- a/stacks/gcp/GcpStack.ts
+++ b/stacks/gcp/GcpStack.ts
@@ -336,7 +336,7 @@ export default class GcpStack extends TerraformStack {
             retryPolicy,
             eventFilters: [
               {
-                attribute: "database",
+                attribute: "document",
                 value: config.document,
               },
             ],
@@ -412,9 +412,8 @@ export default class GcpStack extends TerraformStack {
         resource = "scheduled-" + config.name;
         break;
       case "firestore":
-        eventType = `providers/cloud.firestore/eventTypes/document.${
-          config.firestoreEvent || "write"
-        }`;
+        eventType = `providers/cloud.firestore/eventTypes/document.${config.firestoreEvent || "write"
+          }`;
         resource = config.document;
         break;
       case "storage":


### PR DESCRIPTION
…tabase

# Pull Request

## Description
 Update firestore event trigger type to document instead of database which currently throws an error

## Type of Change
<!-- Mark the appropriate option with an [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Release preparation

## Reviewers
@AndrewBarber @tgerulaitis @iamsambrown @seanpertet 


## Release Checklist
<!-- If this is a release PR, please check the following items -->
If this PR is preparing a release, please ensure:

- [x] The version in `package.json` has been updated following [Semantic Versioning](https://semver.org/) principles
  - [ ] Major version bump for breaking changes
  - [ ] Minor version bump for new features
  - [x] Patch version bump for bug fixes
- [ ] The CHANGELOG.md has been updated with details of the changes under the [Unreleased] section
  - [ ] Added any new features under "### Added"
  - [ ] Documented any changes under "### Changed"
  - [ ] Documented any bug fixes under "### Fixed"
  - [ ] Documented any breaking changes under "### Breaking changes"
- [x] All tests pass locally (`npm run test`)
- [x] Code linting passes (`npm run lint`)
- [x] The PR title clearly describes the changes

### Post-Merge Automation
After merging to master, the following will happen automatically:
- The package will be published to npm
- A GitHub release will be created with the CHANGELOG content
- The PR will be commented with the release information

## Testing

## Additional Notes
